### PR TITLE
PE-5211 Bug Fix : Filter indicators are not updating 

### DIFF
--- a/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset/assets/src/visualizations/FilterBox/FilterBox.jsx
@@ -101,6 +101,13 @@ class FilterBox extends React.Component {
     this.onOpenDateFilterControl = this.onFilterMenuOpen.bind(props.chartId, TIME_RANGE);
   }
 
+  //reset the filter if other filter change in same dashboard also propogate change to filter indicators
+  //Filterbox will get reset if Filterbox is not immune
+  UNSAFE_componentWillReceiveProps(nextProps) {
+      this.changeFilter(Object.keys(nextProps.filtersChoices)[0], "");
+      this.setState({ selectedValues: {} });
+  }  
+
   onFilterMenuOpen(chartId, column) {
     this.props.onFilterMenuOpen(chartId, column);
   }


### PR DESCRIPTION
When loading data into Filterbox the changes is not reflected into the Filter Indicator Boxes

Fix : Call onChange function on props change

Bug is related to PDE Dashboard

