### PR TITLE
Refresh cache o allf charts hourly

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -432,11 +432,9 @@ class CeleryConfig(object):
     CELERYBEAT_SCHEDULE = {
         'cache-warmup-hourly': {
             'task': 'cache-warmup',
-            'schedule': crontab(minute=0, hour='*'),  # hourly
+            'schedule': crontab(minute=1, hour='*'),  # hourly
             'kwargs': {
-                'strategy_name': 'top_n_dashboards',
-                'top_n': 5,
-                'since': '7 days ago',
+                'strategy_name': 'dummy',
             },
         },
     }


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Updated Celery Beat Task to refresh the cache of all dashboard hourly
Code changes are based on the task reference [here](https://github.com/PeakBI/incubator-superset/blob/master/superset/tasks/cache.py#L115-L137){:target="_blank"}
