### PR TITLE
Restrict schema and show only view tables

### DIFF
--- a/superset/assets/src/SqlLab/App.jsx
+++ b/superset/assets/src/SqlLab/App.jsx
@@ -39,6 +39,11 @@ setupApp();
 
 const appContainer = document.getElementById('app');
 const bootstrapData = JSON.parse(appContainer.getAttribute('data-bootstrap'));
+const user = { ...(bootstrapData.user
+             && bootstrapData.user.roles
+             && Object.keys(bootstrapData.user.roles).length
+             && { role_name: Object.keys(bootstrapData.user.roles)[0] }) };
+
 initFeatureFlags(bootstrapData.common.feature_flags);
 const initialState = getInitialState(bootstrapData);
 const sqlLabPersistStateConfig = {
@@ -96,7 +101,7 @@ if (sqlLabMenu) {
 
 const Application = () => (
   <Provider store={store}>
-    <App />
+    <App user={user} />
   </Provider>
 );
 

--- a/superset/assets/src/SqlLab/components/App.jsx
+++ b/superset/assets/src/SqlLab/components/App.jsx
@@ -105,7 +105,7 @@ class App extends React.PureComponent {
       content = (
         <React.Fragment>
           <QueryAutoRefresh />
-          <TabbedSqlEditors />
+          <TabbedSqlEditors user={this.props.user} />
         </React.Fragment>
       );
     }
@@ -119,6 +119,7 @@ class App extends React.PureComponent {
 }
 
 App.propTypes = {
+  user: PropTypes.object,
   actions: PropTypes.object,
   localStorageUsageInKilobytes: PropTypes.number.isRequired,
 };

--- a/superset/assets/src/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditor.jsx
@@ -72,6 +72,7 @@ const propTypes = {
   maxRow: PropTypes.number.isRequired,
   saveQueryWarning: PropTypes.string,
   scheduleQueryWarning: PropTypes.string,
+  user: PropTypes.object,
 };
 
 const defaultProps = {
@@ -79,6 +80,7 @@ const defaultProps = {
   latestQuery: null,
   hideLeftBar: false,
   scheduleQueryWarning: null,
+  user: null,
 };
 
 class SqlEditor extends React.PureComponent {
@@ -463,6 +465,7 @@ class SqlEditor extends React.PureComponent {
         >
           <div className="schemaPane">
             <SqlEditorLeftBar
+              user={this.props.user}
               database={this.props.database}
               queryEditor={this.props.queryEditor}
               tables={this.props.tables}

--- a/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditorLeftBar.jsx
@@ -30,6 +30,7 @@ const propTypes = {
   actions: PropTypes.object,
   database: PropTypes.object,
   offline: PropTypes.bool,
+  user: PropTypes.object,
 };
 
 const defaultProps = {
@@ -37,6 +38,7 @@ const defaultProps = {
   height: 500,
   offline: false,
   tables: [],
+  user: null,
 };
 
 export default class SqlEditorLeftBar extends React.PureComponent {
@@ -104,6 +106,7 @@ export default class SqlEditorLeftBar extends React.PureComponent {
     return (
       <div className="SqlEditorLeftBar">
         <TableSelector
+          user={this.props.user}
           dbId={qe.dbId}
           schema={qe.schema}
           onDbChange={this.onDbChange}

--- a/superset/assets/src/SqlLab/components/TabbedSqlEditors.jsx
+++ b/superset/assets/src/SqlLab/components/TabbedSqlEditors.jsx
@@ -30,6 +30,7 @@ import { areArraysShallowEqual } from '../../reduxUtils';
 import TabStatusIcon from './TabStatusIcon';
 
 const propTypes = {
+  user: PropTypes.object,
   actions: PropTypes.object.isRequired,
   defaultDbId: PropTypes.number,
   defaultQueryLimit: PropTypes.number.isRequired,
@@ -44,6 +45,7 @@ const propTypes = {
   scheduleQueryWarning: PropTypes.string,
 };
 const defaultProps = {
+  user: null,
   queryEditors: [],
   offline: false,
   saveQueryWarning: null,
@@ -241,6 +243,7 @@ class TabbedSqlEditors extends React.PureComponent {
         <Tab key={qe.id} title={tabTitle} eventKey={qe.id}>
           {isSelected && (
             <SqlEditor
+              user={this.props.user}
               tables={this.props.tables.filter(xt => xt.queryEditorId === qe.id)}
               queryEditor={qe}
               editorQueries={this.state.queriesArray}

--- a/superset/assets/src/components/TableSelector.jsx
+++ b/superset/assets/src/components/TableSelector.jsx
@@ -43,6 +43,7 @@ const propTypes = {
   onChange: PropTypes.func,
   clearable: PropTypes.bool,
   handleError: PropTypes.func.isRequired,
+  user: PropTypes.object,
 };
 
 const defaultProps = {
@@ -56,6 +57,7 @@ const defaultProps = {
   tableNameSticky: true,
   sqlLabMode: true,
   clearable: true,
+  user: null,
 };
 
 export default class TableSelector extends React.PureComponent {
@@ -164,7 +166,14 @@ export default class TableSelector extends React.PureComponent {
 
       return SupersetClient.get({ endpoint })
         .then(({ json }) => {
-          const schemaOptions = json.schemas.map(s => ({ value: s, label: s, title: s }));
+          const role = (this.props.user || {}).role_name;
+          const filterschema = [
+           'aws_commons', 'aws_s3', 'common', 'customerai',
+           'demandai', 'information_schema', 'public'];
+
+          const schemaOptions = json.schemas
+          .filter(s => ((role !== 'Admin' && !filterschema.includes(s)) || true))
+          .map(s => ({ value: s, label: s, title: s }));
           this.setState({ schemaOptions, schemaLoading: false });
           this.props.onSchemasLoad(schemaOptions);
         })

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1565,8 +1565,8 @@ class Superset(BaseSupersetView):
                 {
                     "value": vn.table,
                     "schema": vn.schema,
-                    "label": f"[view] {get_datasource_label(vn)}",
-                    "title": f"[view] {get_datasource_label(vn)}",
+                    "label": get_datasource_label(vn),
+                    "title": get_datasource_label(vn),
                 }
                 for vn in views[:max_views]
             ]
@@ -2925,7 +2925,11 @@ class Superset(BaseSupersetView):
     @expose("/sqllab")
     def sqllab(self):
         """SQL Editor"""
+        if not g.user or not g.user.get_id():
+            return redirect(appbuilder.get_url_for_login)
+
         d = {
+            "user": bootstrap_user_data(g.user),
             "defaultDbId": config.get("SQLLAB_DEFAULT_DBID"),
             "common": self.common_bootstrap_payload(),
         }


### PR DESCRIPTION
### Description

- In Schema Selection, remove CustomerAI/Demand AI and other Items showing and show Only "solutions" as  an option with which all the solutions entity table view will be mapped

- In table selection options: Show only table views of solutions entity table. Show only Attribute columns that    are not hidden while showing a table view attribute list. Hidden columns will not be shown here
